### PR TITLE
fix: prevent DialKeyboard crash in verification-code fields

### DIFF
--- a/scripts/apply_patches.py
+++ b/scripts/apply_patches.py
@@ -401,6 +401,18 @@ def apply(
         )
         replace_once(keyboard_xml, original_body, password_body)
 
+    # DialKeyboard is re-parented to PrimeKeyboard below and already overrides
+    # this state callback, so the inherited method must not remain final.
+    prime_keyboard = decoded / (
+        "smali/com/google/android/apps/inputmethod/libs/framework/keyboard/"
+        "PrimeKeyboard.smali"
+    )
+    replace_once(
+        prime_keyboard,
+        ".method protected final a(JJ)V",
+        ".method protected a(JJ)V",
+    )
+
     # DialKeyboard owns phone-specific accessibility announcements. Preserve
     # those overrides while inheriting the same candidate controller used by
     # PrimeKeyboard, instead of replacing the XML class with a generic type.

--- a/scripts/verify_universal_keyboard_header.py
+++ b/scripts/verify_universal_keyboard_header.py
@@ -151,12 +151,26 @@ def main() -> None:
         "smali/com/google/android/apps/inputmethod/libs/framework/keyboard/"
         "DialKeyboard.smali"
     )
+    prime_keyboard = decoded / (
+        "smali/com/google/android/apps/inputmethod/libs/framework/keyboard/"
+        "PrimeKeyboard.smali"
+    )
     dial_text = dial_keyboard.read_text(encoding="utf-8")
+    prime_text = prime_keyboard.read_text(encoding="utf-8")
+    require(
+        ".method protected a(JJ)V" in prime_text
+        and ".method protected final a(JJ)V" not in prime_text,
+        "PrimeKeyboard state callback is still final",
+    )
     require(
         ".super Lcom/google/android/apps/inputmethod/libs/framework/keyboard/"
         "PrimeKeyboard;" in dial_text
         and "PrimeKeyboard;-><init>()V" in dial_text,
         "DialKeyboard does not preserve phone behavior on a candidate-capable base",
+    )
+    require(
+        ".method protected final a(JJ)V" in dial_text,
+        "DialKeyboard phone-state callback is missing",
     )
 
     for variants in PASSWORD_KEYBOARDS:


### PR DESCRIPTION
When an app's numeric verification-code field is routed to `DialKeyboard`, Android cannot load the
keyboard class and terminates the entire Google Pinyin IME process. The user
cannot enter the code with this IME.

The APK still assembles successfully, so build success alone does not catch the
regression. The conflict is only enforced by Android at runtime when
`DialKeyboard` is first loaded: `master` re-parents `DialKeyboard` to
`PrimeKeyboard`, but both classes then declare `a(JJ)V` while the parent method
is still `final`.

## Reproduction

1. Build and install the APK from `master` before this change (`5f6c013`).
2. Enable it and select it as the current input method.
3. Open an app with a numeric verification-code field that selects the phone
   keyboard, then focus the field.
4. The keyboard does not open; the IME process crashes.
5. Inspect `adb logcat`.

Expected: the numeric keyboard opens and the verification code can be entered.

Actual:

```text
[2026-08-16 16:29:00.550 Uid(value=10334):12221:12221 E/AndroidRuntime]
FATAL EXCEPTION: main
Process: com.google.android.inputmethod.pinyin.compat, PID: 12221
java.lang.LinkageError: Method void com.google.android.apps.inputmethod.libs.framework.keyboard.DialKeyboard.a(long, long) overrides final method in class Lcom/google/android/apps/inputmethod/libs/framework/keyboard/PrimeKeyboard; (declaration of 'com.google.android.apps.inputmethod.libs.framework.keyboard.DialKeyboard' appears in /data/app/~~hYm7mOtWhAt6xNnuWLEjRA==/com.google.android.inputmethod.pinyin.compat-ZjHdhsl1t8b9jKO09zpceQ==/base.apk)
 at java.lang.VMClassLoader.findLoadedClass(Native Method)
 at java.lang.ClassLoader.findLoadedClass(ClassLoader.java:1276)
 at java.lang.ClassLoader.loadClass(ClassLoader.java:621)
 at java.lang.ClassLoader.loadClass(ClassLoader.java:573)
 at any.b(PG:74)
 at any.a(PG:40)
 at any.a(PG:27)
 at any.a(PG:16)
 at akq.onKeyboardDefReady(PG:9)
 at akg.a(PG:15)
 at akg.onPostExecute(PG:25)
 at android.os.AsyncTask.finish(AsyncTask.java:771)
 at android.os.AsyncTask.-$$Nest$mfinish(Unknown Source:0)
 at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
 at android.os.Handler.dispatchMessage(Handler.java:109)
 at android.os.Looper.loopOnce(Looper.java:232)
 at android.os.Looper.loop(Looper.java:317)
 at android.app.ActivityThread.main(ActivityThread.java:8934)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```

## Fix

- Remove the inherited `final` modifier from `PrimeKeyboard.a(JJ)V` before
  re-parenting `DialKeyboard`.
- Preserve the phone-specific `DialKeyboard` override and its accessibility
  behavior while retaining the candidate-capable `PrimeKeyboard` base.
- Extend the universal keyboard-header verifier to enforce both sides of this
  override contract and prevent the invalid class hierarchy from returning.

## Testing

- `python3 scripts/verify_universal_keyboard_header.py ../dialfix-build/decoded`
- `python3 -m py_compile scripts/apply_patches.py scripts/verify_universal_keyboard_header.py`
