### PR TITLE
fix: keep composing text height stable

### DIFF
--- a/scripts/apply_patches.py
+++ b/scripts/apply_patches.py
@@ -77,6 +77,17 @@ def apply(
             '<string name="ime_name_ref">Google 拼音输入法（测试版）</string>',
         )
 
+    # Keep the composing popup stable when a Latin pinyin run becomes mixed
+    # Chinese and Latin text under modern target-SDK font measurement.
+    replace_once(
+        decoded / "res/layout/composing_text.xml",
+        '<TextView android:id="@id/composing_text" style="@style/ComposingText"\n'
+        '  xmlns:android="http://schemas.android.com/apk/res/android" />',
+        '<TextView android:id="@id/composing_text" '
+        'android:fallbackLineSpacing="false" style="@style/ComposingText"\n'
+        '  xmlns:android="http://schemas.android.com/apk/res/android" />',
+    )
+
     # Android 12 requires every PendingIntent to declare mutability. None of
     # these seven legacy tokens is modified by its recipient (no RemoteInput,
     # bubbles, fill-in data, or location callback), so preserve the existing

--- a/scripts/verify_target35.py
+++ b/scripts/verify_target35.py
@@ -14,7 +14,6 @@ from pathlib import Path
 FORBIDDEN_BASELINE_REFERENCES = {
     "windowOptOutEdgeToEdgeEnforcement": "temporary edge-to-edge opt-out",
     "elegantTextHeight": "speculative TextView height compensation",
-    "fallbackLineSpacing": "speculative TextView line-spacing compensation",
 }
 
 
@@ -42,6 +41,26 @@ def main() -> None:
             "Target 35 must keep the platform behavior unmasked:\n"
             + "\n".join(findings)
         )
+
+    expected_fallback = 'android:fallbackLineSpacing="false"'
+    fallback_references = []
+    for base, pattern in ((decoded / "smali", "*.smali"), (decoded / "res", "*.xml")):
+        for path in base.rglob(pattern):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            if "fallbackLineSpacing" in text:
+                fallback_references.append((path, text))
+    if len(fallback_references) != 1:
+        raise RuntimeError(
+            "Fallback line spacing override must appear exactly once:\n"
+            + "\n".join(str(path) for path, _ in fallback_references)
+        )
+    fallback_path, fallback_text = fallback_references[0]
+    if (
+        fallback_path.name != "composing_text.xml"
+        or not fallback_path.parent.name.startswith("layout")
+        or fallback_text.count(expected_fallback) != 1
+    ):
+        raise RuntimeError("Fallback line spacing override must remain composing-text-only")
 
     # These pre-existing AppCompat layouts/listeners are part of the legacy UI,
     # not new target-35 compensation. Keep them present for an attributable


### PR DESCRIPTION
## Problem

1. Type `zhe'yang'bu'xing`.
2. Select `zhe'yang` as `这样`.
3. The remaining composing text becomes `这样bu'xing` and grows slightly taller.

## Fix

Disable extra fallback font spacing only for the composing text popup. Other text views keep the default behavior.

## Test

- Rebuilt successfully from the original APK.
- Verified the override appears only in the composing text layout.